### PR TITLE
Monitor nanoflann memory usage during index build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "thirdparty/nanoflann"]
+	path = thirdparty/nanoflann
+	url = https://github.com/jlblancoc/nanoflann.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,9 @@ find_package(rosconsole QUIET)
 if(GTest_FOUND)
     add_executable(debug_containers_test test/debug_containers_test.cpp)
     target_link_libraries(debug_containers_test GTest::gtest GTest::gtest_main)
+
+    add_executable(watcher_test test/nanoflann_watcher_test.cpp)
+    target_link_libraries(watcher_test GTest::gtest GTest::gtest_main)
 endif()
 
 # Example executable
@@ -60,6 +63,7 @@ message(STATUS "  ROS Integration: ${rosconsole_FOUND}")
 message(STATUS "  Executables to build:")
 if(GTest_FOUND)
     message(STATUS "    - debug_containers_test (Google Test)")
+    message(STATUS "    - watcher_test (Google Test)")
 endif()
 message(STATUS "    - memory_debug_example")
 message(STATUS "    - nanoflann_memory_watch_example")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,10 +15,21 @@ include_directories(include)
 include_directories(thirdparty/nanoflann/include)
 
 # Find GTest (optional)
+include(FetchContent)
+set(BUILD_GTEST OFF CACHE BOOL "")
 find_package(GTest QUIET)
+
 if(NOT GTest_FOUND)
-    message(WARNING "GTest not found. Tests will not be built.")
-    message(STATUS "To install GTest: sudo apt-get install libgtest-dev")
+    message(STATUS "GoogleTest not found locally. Fetching via FetchContent...")
+    FetchContent_Declare(
+        googletest
+        URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.zip
+    )
+    # For Windows: Prevent overriding the parent project's compiler/linker settings
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(googletest)
+    # targets GTest::gtest and GTest::gtest_main are provided by googletest project
+    set(GTest_FOUND ON)
 endif()
 
 # Find ROS if available (optional)
@@ -31,6 +42,10 @@ if(GTest_FOUND)
 
     add_executable(watcher_test test/nanoflann_watcher_test.cpp)
     target_link_libraries(watcher_test GTest::gtest GTest::gtest_main)
+
+    include(GoogleTest)
+    gtest_discover_tests(debug_containers_test)
+    gtest_discover_tests(watcher_test)
 endif()
 
 # Example executable

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ endif()
 
 # Example executable
 add_executable(memory_debug_example examples/memory_debug_example.cpp)
+add_executable(nanoflann_memory_watch_example examples/nanoflann_memory_watch_example.cpp)
 
 # Set compiler flags
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
@@ -38,6 +39,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         target_compile_options(debug_containers_test PRIVATE -Wall -Wextra -O2)
     endif()
     target_compile_options(memory_debug_example PRIVATE -Wall -Wextra -O2)
+    target_compile_options(nanoflann_memory_watch_example PRIVATE -Wall -Wextra -O2)
 endif()
 
 # Install rules
@@ -59,3 +61,4 @@ if(GTest_FOUND)
     message(STATUS "    - debug_containers_test (Google Test)")
 endif()
 message(STATUS "    - memory_debug_example")
+message(STATUS "    - nanoflann_memory_watch_example")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 # Include directories
 include_directories(include)
+include_directories(thirdparty/nanoflann/include)
 
 # Find GTest (optional)
 find_package(GTest QUIET)

--- a/examples/nanoflann_memory_watch_example.cpp
+++ b/examples/nanoflann_memory_watch_example.cpp
@@ -1,0 +1,29 @@
+/**
+ * nanoflann memory watch example
+ * ---------------------------------
+ * Demonstrates how to use MemoryWatch::PeakMemoryWatcher (or the helper
+ * function watchPeakMemory) to detect large memory spikes – typical when a
+ * nanoflann index is being built.
+ *
+ * This example purposely allocates a large std::vector to trigger the warning.
+ * Replace the dummy allocation with your actual nanoflann index build.
+ */
+
+#include <memory/nanoflann_memory_watcher.hpp>
+#include <vector>
+#include <iostream>
+
+int main() {
+    constexpr std::size_t THRESHOLD = 50 * 1024 * 1024; // 50 MB
+
+    std::cout << "Watching memory usage with threshold " << (THRESHOLD / (1024*1024)) << " MB..." << std::endl;
+
+    MemoryWatch::watchPeakMemory(THRESHOLD, [](){
+        // Simulate heavy memory usage (~160 MB)
+        std::vector<double> bigVec;
+        bigVec.resize(20'000'000); // 20M doubles ≈ 160 MB
+    });
+
+    std::cout << "Finished without crash." << std::endl;
+    return 0;
+}

--- a/examples/nanoflann_memory_watch_example.cpp
+++ b/examples/nanoflann_memory_watch_example.cpp
@@ -9,21 +9,57 @@
  * Replace the dummy allocation with your actual nanoflann index build.
  */
 
+#include <nanoflann.hpp>
 #include <memory/nanoflann_memory_watcher.hpp>
 #include <vector>
 #include <iostream>
+#include <cstdlib>
+
+// ----- PointCloud adaptor for nanoflann ----
+struct PointCloud {
+    struct Point { double x, y, z; };
+    std::vector<Point> pts;
+
+    // Must return the number of data points
+    inline size_t kdtree_get_point_count() const { return pts.size(); }
+
+    // Returns the dim'th component of the idx'th point in the class:
+    inline double kdtree_get_pt(const size_t idx, const size_t dim) const {
+        if (dim == 0) return pts[idx].x;
+        else if (dim == 1) return pts[idx].y;
+        else return pts[idx].z;
+    }
+
+    // Optional bounding-box computation
+    template <class BBOX>
+    bool kdtree_get_bbox(BBOX&) const { return false; }
+};
 
 int main() {
     constexpr std::size_t THRESHOLD = 50 * 1024 * 1024; // 50 MB
 
     std::cout << "Watching memory usage with threshold " << (THRESHOLD / (1024*1024)) << " MB..." << std::endl;
 
-    MemoryWatch::watchPeakMemory(THRESHOLD, [](){
-        // Simulate heavy memory usage (~160 MB)
-        std::vector<double> bigVec;
-        bigVec.resize(20'000'000); // 20M doubles ≈ 160 MB
-    });
+    PointCloud cloud;
 
+    // Generate many points to make index memory heavy
+    constexpr size_t NPTS = 3'000'000; // 3M points
+    cloud.pts.resize(NPTS);
+    for(size_t i=0;i<NPTS;++i) {
+        cloud.pts[i].x = drand48();
+        cloud.pts[i].y = drand48();
+        cloud.pts[i].z = drand48();
+    }
+
+    using namespace nanoflann;
+    using KDTree = KDTreeSingleIndexAdaptor<
+        L2_Simple_Adaptor<double, PointCloud>, PointCloud, 3 /*dim*/>;
+
+    KDTree index(3, cloud, KDTreeSingleIndexAdaptorParams(10));
+
+    // Watch both RSS and pool memory (pool threshold 30MB)
+    MemoryWatch::watchNanoflannBuild(index, THRESHOLD, 30*1024*1024);
+    
     std::cout << "Finished without crash." << std::endl;
     return 0;
 }

--- a/include/memory/nanoflann_kdtree_limited.hpp
+++ b/include/memory/nanoflann_kdtree_limited.hpp
@@ -1,0 +1,149 @@
+/*
+ * nanoflann_kdtree_limited.hpp
+ * ----------------------------------
+ * A drop-in replacement for nanoflann::KDTreeSingleIndexAdaptor that aborts the
+ * build the very moment the memory budget is exceeded.  It clones the exact
+ * build algorithm of nanoflann 1.6.1 (non-concurrent version) and injects a
+ * test at the start of every recursive divideTree() call.  If the process RSS
+ * Δ or the internal pooled-allocator Δ exceeds the limits supplied by the user
+ * a MemoryExceeded exception is thrown.
+ */
+
+#ifndef NANOFLANN_KDTREE_LIMITED_HPP
+#define NANOFLANN_KDTREE_LIMITED_HPP
+
+#include <nanoflann.hpp>
+#include <memory/nanoflann_memory_watcher.hpp>
+#include <stdexcept>
+#include <unistd.h>
+#include <fstream>
+
+namespace nanoflann_limited {
+
+// Utility: read current RSS in bytes (Linux-/proc based)
+inline std::size_t currentRSS()
+{
+    std::ifstream statm("/proc/self/statm");
+    if (!statm.is_open()) return 0;
+    long pages = 0, resident = 0; statm >> pages >> resident;
+    return std::size_t(resident) * std::size_t(sysconf(_SC_PAGESIZE));
+}
+
+struct MemoryExceeded : public std::runtime_error
+{
+    explicit MemoryExceeded(const char* msg) : std::runtime_error(msg) {}
+};
+
+// The template mirrors KDTreeSingleIndexAdaptor
+template <class Distance, class DatasetAdaptor, int DIM = -1, typename IndexType = size_t>
+class KDTreeSingleIndexAdaptorLimited
+    : public nanoflann::KDTreeSingleIndexAdaptor<Distance, DatasetAdaptor, DIM, IndexType>
+{
+    using Base = nanoflann::KDTreeSingleIndexAdaptor<Distance, DatasetAdaptor, DIM, IndexType>;
+    using BaseBase = typename Base::Base; // KDTreeBaseClass
+    using NodePtr = typename BaseBase::NodePtr;
+    using BoundingBox = typename BaseBase::BoundingBox;
+    using Offset = typename BaseBase::Offset;
+    using Size = typename BaseBase::Size;
+    using Dimension = typename BaseBase::Dimension;
+    using DistanceType = typename BaseBase::DistanceType;
+    using ElementType = typename BaseBase::ElementType;
+
+public:
+    template<typename... Args>
+    KDTreeSingleIndexAdaptorLimited(std::size_t rssLimitBytes,
+                                    std::size_t poolLimitBytes,
+                                    Args&&... args)
+        : Base(std::forward<Args>(args)...),
+          rss_limit_(rssLimitBytes), pool_limit_(poolLimitBytes)
+    {}
+
+    // Re-implemented buildIndex (non-threaded path only)
+    void buildIndex()
+    {
+        baseline_rss_ = currentRSS();
+        auto& obj = *this;
+        BaseBase::size_ = this->dataset_.kdtree_get_point_count();
+        BaseBase::size_at_index_build_ = BaseBase::size_;
+        this->init_vind();
+        this->freeIndex(*this);
+        BaseBase::size_at_index_build_ = BaseBase::size_;
+        if (BaseBase::size_ == 0) return;
+        this->computeBoundingBox(BaseBase::root_bbox_);
+        try {
+            BaseBase::root_node_ = divideTreeLimited(*this, 0, BaseBase::size_, BaseBase::root_bbox_);
+        } catch(...) {
+            // ensure we leave the object in a consistent state (empty tree)
+            this->freeIndex(*this);
+            throw;
+        }
+    }
+
+private:
+    bool exceeded(const BaseBase& obj) const
+    {
+        const std::size_t rss_now = currentRSS();
+        if (rss_limit_ && (rss_now > baseline_rss_) && (rss_now - baseline_rss_ > rss_limit_)) return true;
+        if (pool_limit_ && (obj.pool_.usedMemory + obj.pool_.wastedMemory > pool_limit_)) return true;
+        return false;
+    }
+
+    NodePtr divideTreeLimited(BaseBase& obj, const Offset left, const Offset right, BoundingBox& bbox)
+    {
+        if (exceeded(obj)) throw MemoryExceeded("KD-tree build: memory limit exceeded");
+
+        const auto dims = (DIM > 0 ? DIM : obj.dim_);
+        NodePtr node = obj.pool_.template allocate<typename BaseBase::Node>();
+
+        if ((right - left) <= static_cast<Offset>(obj.leaf_max_size_))
+        {
+            node->child1 = node->child2 = nullptr;
+            node->node_type.lr.left = left;
+            node->node_type.lr.right = right;
+            for (Dimension i = 0; i < dims; ++i)
+            {
+                bbox[i].low  = obj.dataset_get(obj, obj.vAcc_[left], i);
+                bbox[i].high = bbox[i].low;
+            }
+            for (Offset k = left + 1; k < right; ++k)
+            {
+                for (Dimension i = 0; i < dims; ++i)
+                {
+                    const auto val = obj.dataset_get(obj, obj.vAcc_[k], i);
+                    if (bbox[i].low > val) bbox[i].low = val;
+                    if (bbox[i].high < val) bbox[i].high = val;
+                }
+            }
+        }
+        else
+        {
+            Offset idx; Dimension cutfeat; DistanceType cutval;
+            this->middleSplit_(obj, left, right - left, idx, cutfeat, cutval, bbox);
+            node->node_type.sub.divfeat = cutfeat;
+
+            BoundingBox left_bbox(bbox);  left_bbox[cutfeat].high = cutval;
+            node->child1 = divideTreeLimited(obj, left, left + idx, left_bbox);
+
+            BoundingBox right_bbox(bbox); right_bbox[cutfeat].low = cutval;
+            node->child2 = divideTreeLimited(obj, left + idx, right, right_bbox);
+
+            node->node_type.sub.divlow  = left_bbox[cutfeat].high;
+            node->node_type.sub.divhigh = right_bbox[cutfeat].low;
+
+            for (Dimension i = 0; i < dims; ++i)
+            {
+                bbox[i].low  = std::min(left_bbox[i].low,  right_bbox[i].low);
+                bbox[i].high = std::max(left_bbox[i].high, right_bbox[i].high);
+            }
+        }
+        return node;
+    }
+
+    std::size_t rss_limit_;
+    std::size_t pool_limit_;
+    std::size_t baseline_rss_{0};
+};
+
+} // namespace nanoflann_limited
+
+#endif // NANOFLANN_KDTREE_LIMITED_HPP

--- a/include/memory/nanoflann_memory_watcher.hpp
+++ b/include/memory/nanoflann_memory_watcher.hpp
@@ -1,0 +1,153 @@
+#ifndef NANOFLANN_MEMORY_WATCHER_HPP
+#define NANOFLANN_MEMORY_WATCHER_HPP
+
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <functional>
+#include <fstream>
+#include <iostream>
+#include <thread>
+#include <unistd.h>  // for sysconf
+
+namespace MemoryWatch {
+
+/**
+ * PeakMemoryWatcher
+ * -----------------
+ * Lightweight, header-only helper to keep track of the peak Resident Set Size (RSS)
+ * of the current process during a scoped period (e.g. while a nanoflann index is
+ * being built). If the peak memory usage minus the baseline exceeds a user-given
+ * threshold, a user-provided callback is executed (defaults to writing a message
+ * to std::cerr).
+ *
+ * This class is intended to be *non-intrusive* and *low-overhead*:
+ *   1. No modifications of nanoflann or allocation hooks are required.
+ *   2. Sampling is done in a dedicated background thread with a configurable
+ *      period (default 10 ms). The thread sleeps most of the time, so the
+ *      overhead is negligible even for long-running index builds.
+ *   3. Works on Linux by reading /proc/self/statm. (If /proc is not available
+ *      the watcher is silently disabled so it never fails user code.)
+ *
+ * Typical usage:
+ *
+ *   {
+ *       const std::size_t THRESH = 200 * 1024 * 1024; // 200 MB
+ *       MemoryWatch::PeakMemoryWatcher watcher(THRESH);
+ *       index.buildIndex();  // your nanoflann call
+ *       // watcher automatically stops & reports in its destructor.
+ *   }
+ */
+class PeakMemoryWatcher {
+public:
+    using Callback = std::function<void(std::size_t)>;
+
+    explicit PeakMemoryWatcher(std::size_t threshold_bytes,
+                               std::chrono::milliseconds sampling_period = std::chrono::milliseconds(10),
+                               Callback callback = defaultCallback)
+        : threshold_(threshold_bytes),
+          period_(sampling_period),
+          callback_(std::move(callback)),
+          baseline_rss_(currentRSS()),
+          peak_rss_(baseline_rss_),
+          running_(true)
+    {
+        // If currentRSS() returns 0, /proc is probably unavailable – disable.
+        if (baseline_rss_ == 0) {
+            running_ = false;
+            return;
+        }
+        watcher_thread_ = std::thread([this]() { this->watchLoop(); });
+    }
+
+    // Non-copyable / non-movable: watcher owns a thread.
+    PeakMemoryWatcher(const PeakMemoryWatcher&) = delete;
+    PeakMemoryWatcher& operator=(const PeakMemoryWatcher&) = delete;
+
+    ~PeakMemoryWatcher() {
+        if (running_) {
+            running_.store(false, std::memory_order_relaxed);
+            if (watcher_thread_.joinable())
+                watcher_thread_.join();
+        }
+        // Capture RSS one last time, in case we missed the final spike while shutting down.
+        const std::size_t final_rss = currentRSS();
+        if (final_rss > peak_rss_) {
+            peak_rss_ = final_rss;
+        }
+        reportIfExceeded();
+    }
+
+private:
+    static void defaultCallback(std::size_t bytes) {
+        std::cerr << "[MemoryWatch] Peak RSS exceeded threshold by "
+                  << (bytes / (1024.0 * 1024.0)) << " MB (" << bytes << " bytes)."
+                  << std::endl;
+    }
+
+    void watchLoop() {
+        while (running_.load(std::memory_order_relaxed)) {
+            const std::size_t rss = currentRSS();
+            if (rss > peak_rss_) {
+                peak_rss_ = rss;
+            }
+            std::this_thread::sleep_for(period_);
+        }
+    }
+
+    void reportIfExceeded() const {
+        const std::size_t diff = peak_rss_ - baseline_rss_;
+        if (diff > threshold_) {
+            callback_(diff);
+        }
+    }
+
+    // Read the current Resident Set Size (RSS) in bytes. Linux-specific.
+    static std::size_t currentRSS() {
+        std::ifstream statm("/proc/self/statm");
+        if (!statm.is_open()) {
+            return 0; // /proc unavailable – return 0 so watcher disables itself.
+        }
+        long pages_resident = 0;
+        long unused = 0;
+        statm >> unused >> pages_resident;
+        const long page_size = sysconf(_SC_PAGESIZE);
+        return static_cast<std::size_t>(pages_resident) * static_cast<std::size_t>(page_size);
+    }
+
+    // Data members
+    const std::size_t threshold_;
+    const std::chrono::milliseconds period_;
+    const Callback callback_;
+
+    const std::size_t baseline_rss_;
+    std::size_t peak_rss_;
+
+    std::atomic<bool> running_;
+    std::thread watcher_thread_;
+};
+
+// Convenience RAII wrapper to watch memory just for the duration of a callable.
+// Example:
+//   watchPeakMemory(THRESH, [&]{ index.buildIndex(); });
+// This helper spares you from explicitly declaring a PeakMemoryWatcher variable.
+
+template<typename F>
+void watchPeakMemory(std::size_t threshold_bytes,
+                     F&& func,
+                     std::chrono::milliseconds sampling_period = std::chrono::milliseconds(10),
+                     typename PeakMemoryWatcher::Callback cb = nullptr)
+{
+    if (cb) {
+        PeakMemoryWatcher watcher(threshold_bytes, sampling_period, std::move(cb));
+        func();
+    } else {
+        PeakMemoryWatcher watcher(threshold_bytes, sampling_period);
+        func();
+    }
+    // watcher destroyed here, reports automatically
+}
+
+} // namespace MemoryWatch
+
+#endif // NANOFLANN_MEMORY_WATCHER_HPP

--- a/test/nanoflann_watcher_test.cpp
+++ b/test/nanoflann_watcher_test.cpp
@@ -1,0 +1,87 @@
+#include <gtest/gtest.h>
+#include <memory/nanoflann_memory_watcher.hpp>
+#include <atomic>
+#include <vector>
+#include <thread>
+#include <chrono>
+#include <nanoflann.hpp>
+
+// Helper point cloud for nanoflann tests
+struct PointCloud {
+    struct Point { double x,y,z; };
+    std::vector<Point> pts;
+    // nanoflann interface
+    inline size_t kdtree_get_point_count() const { return pts.size(); }
+    inline double kdtree_get_pt(const size_t idx, const size_t dim) const {
+        if(dim==0) return pts[idx].x;
+        if(dim==1) return pts[idx].y;
+        return pts[idx].z;
+    }
+    template<class BBOX> bool kdtree_get_bbox(BBOX&) const { return false; }
+};
+
+TEST(PeakMemoryWatcherTest, CallbackTriggeredWhenExceedsThreshold) {
+    constexpr std::size_t THRESH = 1 * 1024 * 1024; // 1 MB
+    std::atomic<bool> called{false};
+
+    MemoryWatch::watchPeakMemory(
+        THRESH,
+        [&](){
+            std::vector<char> buf(5 * 1024 * 1024); // 5 MB allocation
+            (void)buf.data(); // Suppress unused warning
+        },
+        std::chrono::milliseconds(5),
+        [&](std::size_t){ called = true; }
+    );
+
+    EXPECT_TRUE(called.load());
+}
+
+TEST(PeakMemoryWatcherTest, CallbackNotTriggeredWhenBelowThreshold) {
+    constexpr std::size_t THRESH = 200 * 1024 * 1024; // 200 MB, intentionally high
+    std::atomic<bool> called{false};
+
+    MemoryWatch::watchPeakMemory(
+        THRESH,
+        [&](){
+            std::vector<char> buf(1 * 1024 * 1024); // 1 MB allocation
+            (void)buf.data();
+        },
+        std::chrono::milliseconds(5),
+        [&](std::size_t){ called = true; }
+    );
+
+    EXPECT_FALSE(called.load());
+}
+
+TEST(NanoflannWatcherTest, CallbackTriggeredOnKDTreeBuild) {
+    // Generate a small but non-trivial point cloud
+    PointCloud cloud;
+    constexpr size_t NPTS = 100000; // 100k points ~ 2.4 MB raw data
+    cloud.pts.resize(NPTS);
+    for(size_t i=0;i<NPTS;++i) {
+        cloud.pts[i].x = static_cast<double>(i%1000);
+        cloud.pts[i].y = static_cast<double>((i/1000)%1000);
+        cloud.pts[i].z = static_cast<double>(i);
+    }
+
+    using namespace nanoflann;
+    using Metric   = L2_Simple_Adaptor<double, PointCloud>;
+    using KDTree   = KDTreeSingleIndexAdaptor<Metric, PointCloud, 3>;
+
+    KDTree index(3, cloud, KDTreeSingleIndexAdaptorParams(10));
+
+    std::atomic<bool> called{false};
+    constexpr std::size_t THRESH = 1 * 1024 * 1024; // 1 MB
+
+    MemoryWatch::watchNanoflannBuild(index, THRESH, 0,
+        [&](std::size_t){ called = true; },
+        std::chrono::milliseconds(5));
+
+    EXPECT_TRUE(called.load());
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/test/nanoflann_watcher_test.cpp
+++ b/test/nanoflann_watcher_test.cpp
@@ -1,10 +1,10 @@
 #include <gtest/gtest.h>
-#include <memory/nanoflann_memory_watcher.hpp>
 #include <atomic>
 #include <vector>
 #include <thread>
 #include <chrono>
 #include <nanoflann.hpp>
+#include <memory/nanoflann_memory_watcher.hpp>
 
 // Helper point cloud for nanoflann tests
 struct PointCloud {


### PR DESCRIPTION
Add a non-intrusive, low-overhead memory watcher to monitor process RSS, useful for tracking memory spikes during operations like nanoflann index building.

---

[Open in Web](https://cursor.com/agents?id=bc-7b5f723d-a636-403a-bc4d-a25a3a16ebb6) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-7b5f723d-a636-403a-bc4d-a25a3a16ebb6) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)