### PR TITLE
Monitor nanoflann memory usage during index build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "thirdparty/nanoflann"]
+	path = thirdparty/nanoflann
+	url = https://github.com/jlblancoc/nanoflann.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,10 +33,12 @@ endif()
 # Example executables
 add_executable(memory_debug_example examples/memory_debug_example.cpp)
 add_executable(nanoflann_monitor_example examples/nanoflann_monitor_example.cpp)
+add_executable(nanoflann_auto_monitor_example examples/nanoflann_auto_monitor_example.cpp)
 
 # Link pthread for the nanoflann monitor (needed for std::thread)
 find_package(Threads REQUIRED)
 target_link_libraries(nanoflann_monitor_example Threads::Threads)
+target_link_libraries(nanoflann_auto_monitor_example Threads::Threads)
 
 # Set compiler flags
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
@@ -45,6 +47,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
     endif()
     target_compile_options(memory_debug_example PRIVATE -Wall -Wextra -O2)
     target_compile_options(nanoflann_monitor_example PRIVATE -Wall -Wextra -O2)
+    target_compile_options(nanoflann_auto_monitor_example PRIVATE -Wall -Wextra -O2)
 endif()
 
 # Install rules
@@ -70,3 +73,4 @@ if(GTest_FOUND)
 endif()
 message(STATUS "    - memory_debug_example")
 message(STATUS "    - nanoflann_monitor_example")
+message(STATUS "    - nanoflann_auto_monitor_example")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 
 # Include directories
 include_directories(include)
+include_directories(thirdparty/nanoflann/include)
 
 # Find GTest (optional)
 find_package(GTest QUIET)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,13 @@ if(GTest_FOUND)
     target_link_libraries(debug_containers_test GTest::gtest GTest::gtest_main)
 endif()
 
-# Example executable
+# Example executables
 add_executable(memory_debug_example examples/memory_debug_example.cpp)
+add_executable(nanoflann_monitor_example examples/nanoflann_monitor_example.cpp)
+
+# Link pthread for the nanoflann monitor (needed for std::thread)
+find_package(Threads REQUIRED)
+target_link_libraries(nanoflann_monitor_example Threads::Threads)
 
 # Set compiler flags
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
@@ -38,12 +43,16 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
         target_compile_options(debug_containers_test PRIVATE -Wall -Wextra -O2)
     endif()
     target_compile_options(memory_debug_example PRIVATE -Wall -Wextra -O2)
+    target_compile_options(nanoflann_monitor_example PRIVATE -Wall -Wextra -O2)
 endif()
 
 # Install rules
 install(DIRECTORY include/memory/container_debug/
         DESTINATION include/memory/container_debug/
         FILES_MATCHING PATTERN "*.hpp")
+
+install(FILES include/memory/nanoflann_monitor.hpp
+        DESTINATION include/memory/)
 
 install(FILES docs/MEMORY_DEBUG_GUIDE.md docs/ROS_INTEGRATION_GUIDE.md
         DESTINATION share/debug_containers/docs/)
@@ -59,3 +68,4 @@ if(GTest_FOUND)
     message(STATUS "    - debug_containers_test (Google Test)")
 endif()
 message(STATUS "    - memory_debug_example")
+message(STATUS "    - nanoflann_monitor_example")

--- a/docs/NANOFLANN_MONITOR_GUIDE.md
+++ b/docs/NANOFLANN_MONITOR_GUIDE.md
@@ -1,0 +1,149 @@
+# Nanoflann Memory Monitor Guide
+
+## Overview
+
+The Nanoflann Memory Monitor is a lightweight, non-intrusive tool designed to monitor memory usage during nanoflann KD-tree construction operations. It runs in a background thread and reports when memory usage exceeds specified thresholds.
+
+## Features
+
+- **Real-time monitoring**: Tracks RSS (Resident Set Size) and optionally VSS (Virtual Set Size)
+- **Cross-platform**: Works on Linux, Windows, and macOS
+- **Low overhead**: Configurable check intervals to minimize performance impact
+- **Flexible reporting**: Custom logging functions and threshold configuration
+- **Multiple usage patterns**: Manual control, RAII scoped monitoring, and one-shot measurements
+
+## Quick Start
+
+```cpp
+#include <memory/nanoflann_monitor.hpp>
+#include "nanoflann.hpp"
+
+// Simple scoped monitoring
+{
+    NanoflannMonitor::ScopedMemoryMonitor monitor("KD-tree construction");
+    
+    // Your nanoflann tree building code here
+    my_kd_tree_t index(3, cloud, nanoflann::KDTreeSingleIndexAdaptorParams(10));
+    index.buildIndex();
+}
+// Monitor automatically stops and reports when leaving scope
+```
+
+## Configuration
+
+```cpp
+NanoflannMonitor::MonitorConfig config;
+config.threshold_mb = 100;          // Alert when memory exceeds 100MB
+config.check_interval_ms = 50;      // Check every 50ms
+config.monitor_rss = true;          // Monitor Resident Set Size
+config.monitor_vss = false;         // Don't monitor Virtual Set Size
+config.print_to_stderr = true;      // Print to stderr
+```
+
+## Usage Patterns
+
+### 1. Manual Monitoring
+
+```cpp
+NanoflannMonitor::MemoryMonitor monitor(config);
+monitor.start();
+
+// Perform KD-tree operations
+build_kdtree();
+
+monitor.stop();
+std::cout << "Peak memory: " << monitor.get_peak_stats().rss_bytes / (1024.0 * 1024.0) << " MB\n";
+```
+
+### 2. RAII Scoped Monitoring
+
+```cpp
+{
+    NanoflannMonitor::ScopedMemoryMonitor monitor("My operation", config);
+    // Memory monitoring is active within this scope
+    build_kdtree();
+}
+// Automatically stops and reports when leaving scope
+```
+
+### 3. One-shot Measurement
+
+```cpp
+NanoflannMonitor::measure_memory_usage(
+    []() {
+        build_kdtree();
+    },
+    "KD-tree construction"
+);
+```
+
+### 4. Custom Logging
+
+```cpp
+config.custom_logger = [](const std::string& message) {
+    // Write to file, send to monitoring service, etc.
+    my_logger.log(message);
+};
+config.print_to_stderr = false;  // Disable default output
+```
+
+## Example Output
+
+```
+[NANOFLANN MONITOR] Started monitoring
+  Baseline RSS: 118.61 MB
+  Threshold: 100 MB
+  Check interval: 50 ms
+[NANOFLANN MONITOR] Memory threshold exceeded!
+  Current RSS: 150.23 MB
+  Threshold: 100 MB
+  Exceeded by: 50.23 MB
+  Times exceeded: 1
+[NANOFLANN MONITOR] Stopped monitoring
+  Final RSS: 158.09 MB
+  Peak RSS: 202.36 MB
+  Memory growth: 39.49 MB
+  Threshold exceeded: 71 times
+```
+
+## Performance Considerations
+
+- The monitor runs in a separate thread to avoid blocking KD-tree construction
+- Default check interval is 100ms, which provides good monitoring without significant overhead
+- For very fast operations, consider using one-shot measurement instead of continuous monitoring
+- The monitor uses platform-specific APIs for minimal overhead:
+  - Linux: Reads from `/proc/self/status`
+  - Windows: Uses `GetProcessMemoryInfo`
+  - macOS: Uses `task_info`
+
+## Integration with Nanoflann
+
+The monitor is designed to be completely non-intrusive. Simply wrap your nanoflann operations:
+
+```cpp
+// Before
+my_kd_tree_t index(3, cloud, params);
+index.buildIndex();
+
+// After (with monitoring)
+{
+    NanoflannMonitor::ScopedMemoryMonitor monitor("Building KD-tree");
+    my_kd_tree_t index(3, cloud, params);
+    index.buildIndex();
+}
+```
+
+## Best Practices
+
+1. **Set appropriate thresholds**: Base your threshold on expected memory usage for your data size
+2. **Use scoped monitoring**: Prefer RAII pattern for automatic cleanup
+3. **Adjust check intervals**: For long operations, increase interval to reduce overhead
+4. **Monitor specific operations**: Focus on tree building (`buildIndex()`) where most allocation occurs
+5. **Log to file for production**: Use custom logger to avoid console spam in production
+
+## Troubleshooting
+
+- **No output**: Check that threshold is set appropriately (not too high)
+- **Too much output**: Increase check interval or raise threshold
+- **Platform not supported**: The tool will compile but return zero memory stats
+- **Memory growth calculation**: Negative values may indicate memory was freed during monitoring

--- a/examples/nanoflann_auto_monitor_example.cpp
+++ b/examples/nanoflann_auto_monitor_example.cpp
@@ -1,0 +1,222 @@
+/**
+ * Nanoflann Automatic Memory Monitor Example
+ * 
+ * This example demonstrates how to use the MonitoredKDTree classes that
+ * automatically monitor memory usage during tree operations without
+ * requiring any manual monitoring code.
+ */
+
+#include <memory/nanoflann_monitor_wrapper.hpp>
+#include <iostream>
+#include <vector>
+#include <random>
+#include <chrono>
+
+// Simple point cloud adaptor for 3D points
+template <typename T>
+struct PointCloud {
+    std::vector<T> pts;
+    
+    inline size_t kdtree_get_point_count() const { return pts.size() / 3; }
+    
+    inline T kdtree_get_pt(const size_t idx, const size_t dim) const {
+        return pts[idx * 3 + dim];
+    }
+    
+    template <class BBOX>
+    bool kdtree_get_bbox(BBOX&) const { return false; }
+};
+
+// Generate random point cloud
+template <typename T>
+void generateRandomPointCloud(PointCloud<T>& cloud, size_t num_points) {
+    cloud.pts.resize(num_points * 3);
+    
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_real_distribution<> dis(-1000.0, 1000.0);
+    
+    for (size_t i = 0; i < num_points * 3; ++i) {
+        cloud.pts[i] = dis(gen);
+    }
+}
+
+int main() {
+    std::cout << "Nanoflann Automatic Memory Monitor Example" << std::endl;
+    std::cout << "==========================================" << std::endl;
+    
+    // Example 1: Basic usage with automatic monitoring
+    std::cout << "\n=== Example 1: Basic Automatic Monitoring ===" << std::endl;
+    {
+        PointCloud<double> cloud;
+        generateRandomPointCloud(cloud, 2000000);  // 2M points
+        
+        // Instead of using nanoflann::KDTreeSingleIndexAdaptor directly,
+        // use the monitored version which automatically tracks memory
+        using MonitoredKDTree = NanoflannMonitor::MonitoredKDTreeSingleIndexAdaptor<
+            nanoflann::L2_Simple_Adaptor<double, PointCloud<double>>,
+            PointCloud<double>,
+            3  // dimensions
+        >;
+        
+        // Configure monitoring (50MB threshold)
+        NanoflannMonitor::MonitorConfig config;
+        config.threshold_mb = 50;
+        config.check_interval_ms = 50;
+        
+        // Create tree with monitoring
+        MonitoredKDTree index(3, cloud, nanoflann::KDTreeSingleIndexAdaptorParams(10), config, "Example1_Tree");
+        
+        // Building the index will automatically trigger monitoring
+        std::cout << "\nBuilding KD-tree..." << std::endl;
+        index.buildIndex();
+        // Memory monitoring output appears automatically when threshold is exceeded
+        
+        // Perform some queries (no monitoring for queries as they don't allocate much)
+        const size_t num_queries = 5;
+        for (size_t i = 0; i < num_queries; ++i) {
+            const double query_pt[3] = { 0.0, 0.0, 0.0 };
+            const size_t num_results = 1;
+            uint32_t ret_index;  // Use uint32_t to match IndexType
+            double out_dist_sqr;
+            
+            index.knnSearch(&query_pt[0], num_results, &ret_index, &out_dist_sqr);
+        }
+    }
+    
+    // Example 2: Using the helper function for quick setup
+    std::cout << "\n=== Example 2: Using Helper Function ===" << std::endl;
+    {
+        PointCloud<double> cloud;
+        generateRandomPointCloud(cloud, 3000000);  // 3M points
+        
+        // Create a monitored tree with one line
+        auto index = NanoflannMonitor::makeMonitoredKDTree<
+            nanoflann::L2_Simple_Adaptor<double, PointCloud<double>>,
+            PointCloud<double>,
+            3
+        >(3, cloud, 75, "QuickSetup_Tree");  // 75MB threshold
+        
+        std::cout << "\nBuilding KD-tree with helper..." << std::endl;
+        index.buildIndex();
+    }
+    
+    // Example 3: Dynamic tree with monitoring
+    std::cout << "\n=== Example 3: Dynamic Tree Monitoring ===" << std::endl;
+    {
+        PointCloud<double> cloud;
+        generateRandomPointCloud(cloud, 1000000);  // Start with 1M points
+        
+        using DynamicMonitoredTree = NanoflannMonitor::MonitoredKDTreeDynamicAdaptor<
+            nanoflann::L2_Simple_Adaptor<double, PointCloud<double>>,
+            PointCloud<double>,
+            3
+        >;
+        
+        NanoflannMonitor::MonitorConfig config;
+        config.threshold_mb = 40;
+        
+        DynamicMonitoredTree index(3, cloud, nanoflann::KDTreeSingleIndexAdaptorParams(10), 10000000, config, "Dynamic_Tree");
+        
+        std::cout << "\nInitial tree built automatically with existing points..." << std::endl;
+        
+        // Add more points (this will trigger monitoring if adding many points)
+        std::cout << "\nAdding 50k more points..." << std::endl;
+        size_t old_size = cloud.pts.size();
+        cloud.pts.resize(old_size + 50000 * 3);
+        
+        // Generate new points
+        std::random_device rd;
+        std::mt19937 gen(rd());
+        std::uniform_real_distribution<> dis(-1000.0, 1000.0);
+        for (size_t i = old_size; i < cloud.pts.size(); ++i) {
+            cloud.pts[i] = dis(gen);
+        }
+        
+        // Add points to tree (monitored automatically for large additions)
+        index.addPoints(old_size / 3, (old_size + 50000 * 3) / 3);
+    }
+    
+    // Example 4: Customizing monitoring behavior
+    std::cout << "\n=== Example 4: Custom Monitoring Configuration ===" << std::endl;
+    {
+        PointCloud<double> cloud;
+        generateRandomPointCloud(cloud, 4000000);  // 4M points
+        
+        using MonitoredKDTree = NanoflannMonitor::MonitoredKDTreeSingleIndexAdaptor<
+            nanoflann::L2_Simple_Adaptor<double, PointCloud<double>>,
+            PointCloud<double>,
+            3
+        >;
+        
+        // Custom configuration
+        NanoflannMonitor::MonitorConfig config;
+        config.threshold_mb = 100;
+        config.check_interval_ms = 100;  // Less frequent checks
+        config.monitor_rss = true;
+        config.monitor_vss = false;
+        
+        // Custom logger that could write to a file
+        config.custom_logger = [](const std::string& message) {
+            std::cout << "[CUSTOM OUTPUT] " << message << std::endl;
+        };
+        config.print_to_stderr = false;  // Disable default output
+        
+        MonitoredKDTree index(3, cloud, nanoflann::KDTreeSingleIndexAdaptorParams(10), config, "Custom_Tree");
+        
+        std::cout << "\nBuilding large tree with custom logger..." << std::endl;
+        index.buildIndex();
+    }
+    
+    // Example 5: Comparing with non-monitored version
+    std::cout << "\n=== Example 5: Performance Comparison ===" << std::endl;
+    {
+        PointCloud<double> cloud;
+        generateRandomPointCloud(cloud, 1000000);
+        
+        // Timing with monitoring
+        auto start = std::chrono::high_resolution_clock::now();
+        {
+            using MonitoredKDTree = NanoflannMonitor::MonitoredKDTreeSingleIndexAdaptor<
+                nanoflann::L2_Simple_Adaptor<double, PointCloud<double>>,
+                PointCloud<double>,
+                3
+            >;
+            
+            NanoflannMonitor::MonitorConfig config;
+            config.threshold_mb = 200;  // High threshold to reduce output
+            
+            MonitoredKDTree index(3, cloud, nanoflann::KDTreeSingleIndexAdaptorParams(10), config);
+            index.buildIndex();
+        }
+        auto monitored_time = std::chrono::high_resolution_clock::now() - start;
+        
+        // Timing without monitoring
+        start = std::chrono::high_resolution_clock::now();
+        {
+            using StandardKDTree = nanoflann::KDTreeSingleIndexAdaptor<
+                nanoflann::L2_Simple_Adaptor<double, PointCloud<double>>,
+                PointCloud<double>,
+                3
+            >;
+            
+            StandardKDTree index(3, cloud, nanoflann::KDTreeSingleIndexAdaptorParams(10));
+            index.buildIndex();
+        }
+        auto standard_time = std::chrono::high_resolution_clock::now() - start;
+        
+        std::cout << "\nPerformance comparison:" << std::endl;
+        std::cout << "  With monitoring: " 
+                  << std::chrono::duration_cast<std::chrono::milliseconds>(monitored_time).count() 
+                  << " ms" << std::endl;
+        std::cout << "  Without monitoring: " 
+                  << std::chrono::duration_cast<std::chrono::milliseconds>(standard_time).count() 
+                  << " ms" << std::endl;
+        std::cout << "  Overhead: " 
+                  << (100.0 * (monitored_time.count() - standard_time.count()) / standard_time.count())
+                  << "%" << std::endl;
+    }
+    
+    std::cout << "\nAll examples completed!" << std::endl;
+    return 0;
+}

--- a/examples/nanoflann_monitor_example.cpp
+++ b/examples/nanoflann_monitor_example.cpp
@@ -1,0 +1,201 @@
+/**
+ * Nanoflann Memory Monitor Example
+ * 
+ * This example demonstrates how to monitor memory usage during nanoflann
+ * KD-tree construction operations. The monitor is designed to be non-intrusive
+ * and low-overhead, running in a background thread.
+ * 
+ * To use this example, you'll need to have nanoflann installed.
+ * If not installed, you can get it from: https://github.com/jlblancoc/nanoflann
+ */
+
+#include <memory/nanoflann_monitor.hpp>
+#include <iostream>
+#include <vector>
+#include <random>
+#include <chrono>
+
+// Uncomment this when you have nanoflann installed
+// #include "nanoflann.hpp"
+
+// For demonstration purposes, we'll simulate a KD-tree build operation
+void simulate_kdtree_build(size_t num_points, size_t dimensions) {
+    std::cout << "\nSimulating KD-tree build with " << num_points 
+              << " points in " << dimensions << "D space..." << std::endl;
+    
+    // Allocate memory for points (simulating what nanoflann would do)
+    std::vector<std::vector<double>> points(num_points);
+    
+    // Generate random points
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_real_distribution<> dis(-100.0, 100.0);
+    
+    for (size_t i = 0; i < num_points; ++i) {
+        points[i].resize(dimensions);
+        for (size_t j = 0; j < dimensions; ++j) {
+            points[i][j] = dis(gen);
+        }
+    }
+    
+    // Simulate tree construction delay
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+}
+
+// Example 1: Using manual start/stop monitoring
+void example_manual_monitoring() {
+    std::cout << "\n=== Example 1: Manual Monitoring ===" << std::endl;
+    
+    // Create monitor with custom configuration
+    NanoflannMonitor::MonitorConfig config;
+    config.threshold_mb = 50;           // Alert when memory exceeds 50MB
+    config.check_interval_ms = 50;      // Check every 50ms
+    config.monitor_rss = true;          // Monitor resident set size
+    config.monitor_vss = false;         // Don't monitor virtual size
+    
+    NanoflannMonitor::MemoryMonitor monitor(config);
+    
+    // Start monitoring
+    monitor.start();
+    
+    // Perform operations that allocate memory
+    simulate_kdtree_build(1000000, 3);    // 1M points in 3D
+    simulate_kdtree_build(2000000, 3);    // 2M points in 3D
+    
+    // Stop monitoring
+    monitor.stop();
+    
+    // Get statistics
+    std::cout << "\nThreshold exceeded " << monitor.get_threshold_exceeded_count() 
+              << " times during monitoring." << std::endl;
+}
+
+// Example 2: Using RAII scoped monitoring
+void example_scoped_monitoring() {
+    std::cout << "\n=== Example 2: Scoped Monitoring ===" << std::endl;
+    
+    NanoflannMonitor::MonitorConfig config;
+    config.threshold_mb = 30;
+    config.check_interval_ms = 25;  // More frequent checks
+    
+    {
+        // Monitor automatically starts when entering scope
+        NanoflannMonitor::ScopedMemoryMonitor monitor("Large KD-tree construction", config);
+        
+        simulate_kdtree_build(500000, 10);   // 500k points in 10D
+        simulate_kdtree_build(1000000, 10);  // 1M points in 10D
+        
+        // Monitor automatically stops when leaving scope
+    }
+}
+
+// Example 3: Using one-shot memory measurement
+void example_oneshot_measurement() {
+    std::cout << "\n=== Example 3: One-shot Measurement ===" << std::endl;
+    
+    // Measure memory usage of a specific operation
+    NanoflannMonitor::measure_memory_usage(
+        []() {
+            simulate_kdtree_build(3000000, 5);  // 3M points in 5D
+        },
+        "3M point KD-tree construction"
+    );
+}
+
+// Example 4: Using custom logger
+void example_custom_logger() {
+    std::cout << "\n=== Example 4: Custom Logger ===" << std::endl;
+    
+    // Create a custom logger that writes to a file or custom output
+    auto custom_logger = [](const std::string& message) {
+        // In real usage, this could write to a log file, send to monitoring service, etc.
+        std::cout << "[CUSTOM LOG] " << message << std::endl;
+    };
+    
+    NanoflannMonitor::MonitorConfig config;
+    config.threshold_mb = 40;
+    config.custom_logger = custom_logger;
+    config.print_to_stderr = false;  // Disable default stderr output
+    
+    NanoflannMonitor::MemoryMonitor monitor(config);
+    monitor.start();
+    
+    simulate_kdtree_build(1500000, 4);  // 1.5M points in 4D
+    
+    monitor.stop();
+}
+
+// Real nanoflann example (uncomment when nanoflann is available)
+/*
+template <typename T>
+struct PointCloud {
+    std::vector<T> pts;
+    
+    inline size_t kdtree_get_point_count() const { return pts.size() / 3; }
+    
+    inline T kdtree_get_pt(const size_t idx, const size_t dim) const {
+        return pts[idx * 3 + dim];
+    }
+    
+    template <class BBOX>
+    bool kdtree_get_bbox(BBOX&) const { return false; }
+};
+
+void example_real_nanoflann() {
+    std::cout << "\n=== Real Nanoflann Example ===" << std::endl;
+    
+    // Configure monitoring
+    NanoflannMonitor::MonitorConfig config;
+    config.threshold_mb = 100;
+    config.check_interval_ms = 50;
+    
+    // Create point cloud
+    PointCloud<double> cloud;
+    const size_t num_points = 5000000;  // 5M points
+    
+    // Generate random points
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_real_distribution<> dis(-1000.0, 1000.0);
+    
+    cloud.pts.resize(num_points * 3);
+    for (size_t i = 0; i < num_points * 3; ++i) {
+        cloud.pts[i] = dis(gen);
+    }
+    
+    // Monitor KD-tree construction
+    {
+        NanoflannMonitor::ScopedMemoryMonitor monitor("Nanoflann KD-tree build", config);
+        
+        // Build KD-tree
+        using my_kd_tree_t = nanoflann::KDTreeSingleIndexAdaptor<
+            nanoflann::L2_Simple_Adaptor<double, PointCloud<double>>,
+            PointCloud<double>,
+            3
+        >;
+        
+        my_kd_tree_t index(3, cloud, nanoflann::KDTreeSingleIndexAdaptorParams(10));
+        index.buildIndex();
+        
+        std::cout << "KD-tree built with " << num_points << " points" << std::endl;
+    }
+}
+*/
+
+int main() {
+    std::cout << "Nanoflann Memory Monitor Examples" << std::endl;
+    std::cout << "=================================" << std::endl;
+    
+    // Run examples
+    example_manual_monitoring();
+    example_scoped_monitoring();
+    example_oneshot_measurement();
+    example_custom_logger();
+    
+    // Uncomment when nanoflann is available
+    // example_real_nanoflann();
+    
+    std::cout << "\nAll examples completed!" << std::endl;
+    
+    return 0;
+}

--- a/examples/nanoflann_monitor_example.cpp
+++ b/examples/nanoflann_monitor_example.cpp
@@ -15,8 +15,7 @@
 #include <random>
 #include <chrono>
 
-// Uncomment this when you have nanoflann installed
-// #include "nanoflann.hpp"
+#include "nanoflann.hpp"
 
 // For demonstration purposes, we'll simulate a KD-tree build operation
 void simulate_kdtree_build(size_t num_points, size_t dimensions) {
@@ -125,8 +124,7 @@ void example_custom_logger() {
     monitor.stop();
 }
 
-// Real nanoflann example (uncomment when nanoflann is available)
-/*
+// Real nanoflann example
 template <typename T>
 struct PointCloud {
     std::vector<T> pts;
@@ -180,7 +178,6 @@ void example_real_nanoflann() {
         std::cout << "KD-tree built with " << num_points << " points" << std::endl;
     }
 }
-*/
 
 int main() {
     std::cout << "Nanoflann Memory Monitor Examples" << std::endl;
@@ -192,8 +189,7 @@ int main() {
     example_oneshot_measurement();
     example_custom_logger();
     
-    // Uncomment when nanoflann is available
-    // example_real_nanoflann();
+    example_real_nanoflann();
     
     std::cout << "\nAll examples completed!" << std::endl;
     

--- a/include/memory/nanoflann_monitor.hpp
+++ b/include/memory/nanoflann_monitor.hpp
@@ -1,0 +1,304 @@
+#ifndef NANOFLANN_MEMORY_MONITOR_HPP
+#define NANOFLANN_MEMORY_MONITOR_HPP
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <thread>
+#include <vector>
+
+#ifdef __linux__
+#include <fstream>
+#include <unistd.h>
+#elif defined(_WIN32)
+#include <windows.h>
+#include <psapi.h>
+#elif defined(__APPLE__)
+#include <mach/mach.h>
+#endif
+
+namespace NanoflannMonitor {
+
+// Forward declarations
+class MemoryMonitor;
+class ScopedMemoryMonitor;
+
+// Configuration structure
+struct MonitorConfig {
+    size_t threshold_mb = 100;          // Memory threshold in MB
+    size_t check_interval_ms = 100;     // How often to check memory (milliseconds)
+    bool monitor_rss = true;            // Monitor RSS (Resident Set Size)
+    bool monitor_vss = false;           // Monitor VSS (Virtual Set Size)
+    bool print_to_stderr = true;        // Print to stderr
+    std::function<void(const std::string&)> custom_logger = nullptr;  // Custom logging function
+};
+
+// Memory statistics
+struct MemoryStats {
+    size_t rss_bytes = 0;       // Resident Set Size in bytes
+    size_t vss_bytes = 0;       // Virtual Set Size in bytes
+    size_t peak_rss_bytes = 0;  // Peak RSS during monitoring
+    std::chrono::steady_clock::time_point timestamp;
+};
+
+// Platform-specific memory reading functions
+namespace PlatformMemory {
+    
+#ifdef __linux__
+    inline MemoryStats get_current_memory() {
+        MemoryStats stats;
+        stats.timestamp = std::chrono::steady_clock::now();
+        
+        std::ifstream status("/proc/self/status");
+        std::string line;
+        
+        while (std::getline(status, line)) {
+            if (line.substr(0, 6) == "VmRSS:") {
+                std::istringstream iss(line.substr(6));
+                size_t rss_kb;
+                iss >> rss_kb;
+                stats.rss_bytes = rss_kb * 1024;
+            } else if (line.substr(0, 6) == "VmSize") {
+                std::istringstream iss(line.substr(7));
+                size_t vss_kb;
+                iss >> vss_kb;
+                stats.vss_bytes = vss_kb * 1024;
+            }
+        }
+        
+        return stats;
+    }
+    
+#elif defined(_WIN32)
+    inline MemoryStats get_current_memory() {
+        MemoryStats stats;
+        stats.timestamp = std::chrono::steady_clock::now();
+        
+        PROCESS_MEMORY_COUNTERS_EX pmc;
+        if (GetProcessMemoryInfo(GetCurrentProcess(), 
+                                (PROCESS_MEMORY_COUNTERS*)&pmc, sizeof(pmc))) {
+            stats.rss_bytes = pmc.WorkingSetSize;
+            stats.vss_bytes = pmc.PrivateUsage;
+        }
+        
+        return stats;
+    }
+    
+#elif defined(__APPLE__)
+    inline MemoryStats get_current_memory() {
+        MemoryStats stats;
+        stats.timestamp = std::chrono::steady_clock::now();
+        
+        struct task_basic_info info;
+        mach_msg_type_number_t info_count = TASK_BASIC_INFO_COUNT;
+        
+        if (task_info(mach_task_self(), TASK_BASIC_INFO, 
+                     (task_info_t)&info, &info_count) == KERN_SUCCESS) {
+            stats.rss_bytes = info.resident_size;
+            stats.vss_bytes = info.virtual_size;
+        }
+        
+        return stats;
+    }
+    
+#else
+    inline MemoryStats get_current_memory() {
+        return MemoryStats{};  // Unsupported platform
+    }
+#endif
+
+} // namespace PlatformMemory
+
+// Main memory monitor class
+class MemoryMonitor {
+private:
+    MonitorConfig config_;
+    std::atomic<bool> monitoring_{false};
+    std::atomic<bool> should_stop_{false};
+    std::unique_ptr<std::thread> monitor_thread_;
+    MemoryStats baseline_stats_;
+    MemoryStats peak_stats_;
+    std::atomic<size_t> threshold_exceeded_count_{0};
+    
+    void log_message(const std::string& message) {
+        if (config_.custom_logger) {
+            config_.custom_logger(message);
+        } else if (config_.print_to_stderr) {
+            std::cerr << message << std::endl;
+        }
+    }
+    
+    void monitor_loop() {
+        while (!should_stop_.load()) {
+            auto current = PlatformMemory::get_current_memory();
+            
+            // Update peak RSS
+            if (current.rss_bytes > peak_stats_.rss_bytes) {
+                peak_stats_ = current;
+            }
+            
+            // Check thresholds
+            size_t threshold_bytes = config_.threshold_mb * 1024 * 1024;
+            
+            if (config_.monitor_rss && current.rss_bytes > threshold_bytes) {
+                threshold_exceeded_count_++;
+                
+                std::ostringstream oss;
+                oss << "[NANOFLANN MONITOR] Memory threshold exceeded!\n"
+                    << "  Current RSS: " << std::fixed << std::setprecision(2) 
+                    << (current.rss_bytes / (1024.0 * 1024.0)) << " MB\n"
+                    << "  Threshold: " << config_.threshold_mb << " MB\n"
+                    << "  Exceeded by: " << std::fixed << std::setprecision(2)
+                    << ((current.rss_bytes - threshold_bytes) / (1024.0 * 1024.0)) << " MB\n"
+                    << "  Times exceeded: " << threshold_exceeded_count_.load();
+                
+                if (config_.monitor_vss) {
+                    oss << "\n  Current VSS: " << std::fixed << std::setprecision(2)
+                        << (current.vss_bytes / (1024.0 * 1024.0)) << " MB";
+                }
+                
+                log_message(oss.str());
+            }
+            
+            std::this_thread::sleep_for(std::chrono::milliseconds(config_.check_interval_ms));
+        }
+    }
+    
+public:
+    explicit MemoryMonitor(const MonitorConfig& config = MonitorConfig{})
+        : config_(config) {}
+    
+    ~MemoryMonitor() {
+        stop();
+    }
+    
+    // Start monitoring
+    void start() {
+        if (monitoring_.load()) return;
+        
+        baseline_stats_ = PlatformMemory::get_current_memory();
+        peak_stats_ = baseline_stats_;
+        threshold_exceeded_count_ = 0;
+        should_stop_ = false;
+        monitoring_ = true;
+        
+        monitor_thread_ = std::make_unique<std::thread>(&MemoryMonitor::monitor_loop, this);
+        
+        std::ostringstream oss;
+        oss << "[NANOFLANN MONITOR] Started monitoring\n"
+            << "  Baseline RSS: " << std::fixed << std::setprecision(2)
+            << (baseline_stats_.rss_bytes / (1024.0 * 1024.0)) << " MB\n"
+            << "  Threshold: " << config_.threshold_mb << " MB\n"
+            << "  Check interval: " << config_.check_interval_ms << " ms";
+        
+        log_message(oss.str());
+    }
+    
+    // Stop monitoring
+    void stop() {
+        if (!monitoring_.load()) return;
+        
+        should_stop_ = true;
+        if (monitor_thread_ && monitor_thread_->joinable()) {
+            monitor_thread_->join();
+        }
+        monitoring_ = false;
+        
+        auto final_stats = PlatformMemory::get_current_memory();
+        
+        std::ostringstream oss;
+        oss << "[NANOFLANN MONITOR] Stopped monitoring\n"
+            << "  Final RSS: " << std::fixed << std::setprecision(2)
+            << (final_stats.rss_bytes / (1024.0 * 1024.0)) << " MB\n"
+            << "  Peak RSS: " << std::fixed << std::setprecision(2)
+            << (peak_stats_.rss_bytes / (1024.0 * 1024.0)) << " MB\n"
+            << "  Memory growth: " << std::fixed << std::setprecision(2)
+            << ((final_stats.rss_bytes - baseline_stats_.rss_bytes) / (1024.0 * 1024.0)) << " MB\n"
+            << "  Threshold exceeded: " << threshold_exceeded_count_.load() << " times";
+        
+        log_message(oss.str());
+    }
+    
+    // Get current statistics
+    MemoryStats get_current_stats() const {
+        return PlatformMemory::get_current_memory();
+    }
+    
+    MemoryStats get_peak_stats() const {
+        return peak_stats_;
+    }
+    
+    size_t get_threshold_exceeded_count() const {
+        return threshold_exceeded_count_.load();
+    }
+    
+    bool is_monitoring() const {
+        return monitoring_.load();
+    }
+};
+
+// RAII wrapper for scoped monitoring
+class ScopedMemoryMonitor {
+private:
+    MemoryMonitor monitor_;
+    std::string scope_name_;
+    
+public:
+    ScopedMemoryMonitor(const std::string& scope_name, 
+                       const MonitorConfig& config = MonitorConfig{})
+        : monitor_(config), scope_name_(scope_name) {
+        
+        if (config.custom_logger) {
+            config.custom_logger("[NANOFLANN MONITOR] Entering scope: " + scope_name);
+        } else if (config.print_to_stderr) {
+            std::cerr << "[NANOFLANN MONITOR] Entering scope: " << scope_name << std::endl;
+        }
+        
+        monitor_.start();
+    }
+    
+    ~ScopedMemoryMonitor() {
+        monitor_.stop();
+        
+        auto& config = monitor_.config_;
+        if (config.custom_logger) {
+            config.custom_logger("[NANOFLANN MONITOR] Exiting scope: " + scope_name_);
+        } else if (config.print_to_stderr) {
+            std::cerr << "[NANOFLANN MONITOR] Exiting scope: " << scope_name_ << std::endl;
+        }
+    }
+    
+    // Delete copy/move operations
+    ScopedMemoryMonitor(const ScopedMemoryMonitor&) = delete;
+    ScopedMemoryMonitor& operator=(const ScopedMemoryMonitor&) = delete;
+    ScopedMemoryMonitor(ScopedMemoryMonitor&&) = delete;
+    ScopedMemoryMonitor& operator=(ScopedMemoryMonitor&&) = delete;
+};
+
+// Convenience function for one-shot memory measurement
+inline MemoryStats measure_memory_usage(std::function<void()> operation,
+                                       const std::string& operation_name = "operation") {
+    auto before = PlatformMemory::get_current_memory();
+    operation();
+    auto after = PlatformMemory::get_current_memory();
+    
+    std::ostringstream oss;
+    oss << "[NANOFLANN MONITOR] Memory usage for " << operation_name << ":\n"
+        << "  RSS growth: " << std::fixed << std::setprecision(2)
+        << ((after.rss_bytes - before.rss_bytes) / (1024.0 * 1024.0)) << " MB\n"
+        << "  Final RSS: " << std::fixed << std::setprecision(2)
+        << (after.rss_bytes / (1024.0 * 1024.0)) << " MB";
+    
+    std::cerr << oss.str() << std::endl;
+    
+    return after;
+}
+
+} // namespace NanoflannMonitor
+
+#endif // NANOFLANN_MEMORY_MONITOR_HPP

--- a/include/memory/nanoflann_monitor.hpp
+++ b/include/memory/nanoflann_monitor.hpp
@@ -247,15 +247,16 @@ class ScopedMemoryMonitor {
 private:
     MemoryMonitor monitor_;
     std::string scope_name_;
+    MonitorConfig config_;
     
 public:
     ScopedMemoryMonitor(const std::string& scope_name, 
                        const MonitorConfig& config = MonitorConfig{})
-        : monitor_(config), scope_name_(scope_name) {
+        : monitor_(config), scope_name_(scope_name), config_(config) {
         
-        if (config.custom_logger) {
-            config.custom_logger("[NANOFLANN MONITOR] Entering scope: " + scope_name);
-        } else if (config.print_to_stderr) {
+        if (config_.custom_logger) {
+            config_.custom_logger("[NANOFLANN MONITOR] Entering scope: " + scope_name);
+        } else if (config_.print_to_stderr) {
             std::cerr << "[NANOFLANN MONITOR] Entering scope: " << scope_name << std::endl;
         }
         
@@ -265,10 +266,9 @@ public:
     ~ScopedMemoryMonitor() {
         monitor_.stop();
         
-        auto& config = monitor_.config_;
-        if (config.custom_logger) {
-            config.custom_logger("[NANOFLANN MONITOR] Exiting scope: " + scope_name_);
-        } else if (config.print_to_stderr) {
+        if (config_.custom_logger) {
+            config_.custom_logger("[NANOFLANN MONITOR] Exiting scope: " + scope_name_);
+        } else if (config_.print_to_stderr) {
             std::cerr << "[NANOFLANN MONITOR] Exiting scope: " << scope_name_ << std::endl;
         }
     }

--- a/include/memory/nanoflann_monitor_wrapper.hpp
+++ b/include/memory/nanoflann_monitor_wrapper.hpp
@@ -1,0 +1,295 @@
+#ifndef NANOFLANN_MONITOR_WRAPPER_HPP
+#define NANOFLANN_MONITOR_WRAPPER_HPP
+
+#include "nanoflann.hpp"
+#include "nanoflann_monitor.hpp"
+#include <memory>
+#include <string>
+
+namespace NanoflannMonitor {
+
+/**
+ * A wrapper for nanoflann KDTreeSingleIndexAdaptor that automatically monitors memory usage
+ * during tree construction and other memory-intensive operations.
+ * 
+ * This class inherits from nanoflann's KDTreeSingleIndexAdaptor and adds automatic
+ * memory monitoring without requiring any changes to your existing code.
+ * 
+ * Usage:
+ *   // Instead of:
+ *   using my_kd_tree_t = nanoflann::KDTreeSingleIndexAdaptor<...>;
+ *   
+ *   // Use:
+ *   using my_kd_tree_t = NanoflannMonitor::MonitoredKDTreeSingleIndexAdaptor<...>;
+ */
+template <typename Distance, typename DatasetAdaptor, int32_t DIM = -1, typename IndexType = uint32_t>
+class MonitoredKDTreeSingleIndexAdaptor : public nanoflann::KDTreeSingleIndexAdaptor<Distance, DatasetAdaptor, DIM, IndexType> {
+public:
+    using BaseClass = nanoflann::KDTreeSingleIndexAdaptor<Distance, DatasetAdaptor, DIM, IndexType>;
+    using Params = nanoflann::KDTreeSingleIndexAdaptorParams;
+    
+private:
+    mutable MonitorConfig monitor_config_;
+    mutable std::unique_ptr<MemoryMonitor> active_monitor_;
+    std::string tree_name_;
+    
+    void start_monitoring(const std::string& operation) const {
+        if (active_monitor_ && active_monitor_->is_monitoring()) {
+            return; // Already monitoring
+        }
+        
+        active_monitor_ = std::make_unique<MemoryMonitor>(monitor_config_);
+        
+        // Log operation start
+        std::ostringstream oss;
+        oss << "[NANOFLANN MONITOR] Starting " << operation;
+        if (!tree_name_.empty()) {
+            oss << " for tree '" << tree_name_ << "'";
+        }
+        
+        if (monitor_config_.custom_logger) {
+            monitor_config_.custom_logger(oss.str());
+        } else if (monitor_config_.print_to_stderr) {
+            std::cerr << oss.str() << std::endl;
+        }
+        
+        active_monitor_->start();
+    }
+    
+    void stop_monitoring(const std::string& operation) const {
+        if (!active_monitor_ || !active_monitor_->is_monitoring()) {
+            return;
+        }
+        
+        auto peak_stats = active_monitor_->get_peak_stats();
+        auto exceeded_count = active_monitor_->get_threshold_exceeded_count();
+        
+        active_monitor_->stop();
+        
+        // Log operation completion with summary
+        std::ostringstream oss;
+        oss << "[NANOFLANN MONITOR] Completed " << operation;
+        if (!tree_name_.empty()) {
+            oss << " for tree '" << tree_name_ << "'";
+        }
+        oss << "\n  Peak memory: " << std::fixed << std::setprecision(2)
+            << (peak_stats.rss_bytes / (1024.0 * 1024.0)) << " MB";
+        if (exceeded_count > 0) {
+            oss << " (threshold exceeded " << exceeded_count << " times)";
+        }
+        
+        if (monitor_config_.custom_logger) {
+            monitor_config_.custom_logger(oss.str());
+        } else if (monitor_config_.print_to_stderr) {
+            std::cerr << oss.str() << std::endl;
+        }
+        
+        active_monitor_.reset();
+    }
+    
+public:
+    /**
+     * Constructor with monitoring configuration
+     * @param dimensionality Dimensionality of the points
+     * @param inputData Dataset adaptor
+     * @param params KD-tree parameters
+     * @param monitor_config Memory monitoring configuration
+     * @param tree_name Optional name for this tree (used in logging)
+     */
+    MonitoredKDTreeSingleIndexAdaptor(
+        const int dimensionality,
+        const DatasetAdaptor& inputData,
+        const Params& params = Params(),
+        const MonitorConfig& monitor_config = MonitorConfig{},
+        const std::string& tree_name = "")
+        : BaseClass(dimensionality, inputData, params)
+        , monitor_config_(monitor_config)
+        , tree_name_(tree_name) {
+    }
+    
+    /**
+     * Build the KD-tree index with automatic memory monitoring
+     */
+    void buildIndex() {
+        start_monitoring("buildIndex()");
+        
+        try {
+            BaseClass::buildIndex();
+            stop_monitoring("buildIndex()");
+        } catch (...) {
+            stop_monitoring("buildIndex() (failed)");
+            throw;
+        }
+    }
+    
+    /**
+     * Set the memory monitoring configuration
+     */
+    void setMonitorConfig(const MonitorConfig& config) {
+        monitor_config_ = config;
+    }
+    
+    /**
+     * Get the current monitoring configuration
+     */
+    const MonitorConfig& getMonitorConfig() const {
+        return monitor_config_;
+    }
+    
+    /**
+     * Set a name for this tree (used in logging)
+     */
+    void setTreeName(const std::string& name) {
+        tree_name_ = name;
+    }
+    
+    /**
+     * Get the tree name
+     */
+    const std::string& getTreeName() const {
+        return tree_name_;
+    }
+    
+    /**
+     * Enable or disable monitoring
+     */
+    void setMonitoringEnabled(bool enabled) {
+        monitor_config_.print_to_stderr = enabled;
+    }
+};
+
+/**
+ * A wrapper for nanoflann KDTreeSingleIndexDynamicAdaptor that automatically monitors memory usage
+ * This is for the dynamic version that supports adding/removing points
+ */
+template <typename Distance, typename DatasetAdaptor, int32_t DIM = -1, typename IndexType = uint32_t>
+class MonitoredKDTreeDynamicAdaptor : public nanoflann::KDTreeSingleIndexDynamicAdaptor<Distance, DatasetAdaptor, DIM, IndexType> {
+public:
+    using BaseClass = nanoflann::KDTreeSingleIndexDynamicAdaptor<Distance, DatasetAdaptor, DIM, IndexType>;
+    using Params = nanoflann::KDTreeSingleIndexAdaptorParams;
+    
+private:
+    mutable MonitorConfig monitor_config_;
+    mutable std::unique_ptr<MemoryMonitor> active_monitor_;
+    std::string tree_name_;
+    
+    void start_monitoring(const std::string& operation) const {
+        if (active_monitor_ && active_monitor_->is_monitoring()) {
+            return;
+        }
+        
+        active_monitor_ = std::make_unique<MemoryMonitor>(monitor_config_);
+        active_monitor_->start();
+    }
+    
+    void stop_monitoring(const std::string& operation) const {
+        if (!active_monitor_ || !active_monitor_->is_monitoring()) {
+            return;
+        }
+        
+        auto exceeded_count = active_monitor_->get_threshold_exceeded_count();
+        if (exceeded_count > 0) {
+            auto peak_stats = active_monitor_->get_peak_stats();
+            
+            std::ostringstream oss;
+            oss << "[NANOFLANN MONITOR] " << operation;
+            if (!tree_name_.empty()) {
+                oss << " for tree '" << tree_name_ << "'";
+            }
+            oss << " - Peak memory: " << std::fixed << std::setprecision(2)
+                << (peak_stats.rss_bytes / (1024.0 * 1024.0)) << " MB"
+                << " (threshold exceeded)";
+            
+            if (monitor_config_.custom_logger) {
+                monitor_config_.custom_logger(oss.str());
+            } else if (monitor_config_.print_to_stderr) {
+                std::cerr << oss.str() << std::endl;
+            }
+        }
+        
+        active_monitor_->stop();
+        active_monitor_.reset();
+    }
+    
+public:
+    MonitoredKDTreeDynamicAdaptor(
+        const int dimensionality,
+        const DatasetAdaptor& inputData,
+        const Params& params = Params(),
+        const size_t maximumPointCount = 1000000000U,
+        const MonitorConfig& monitor_config = MonitorConfig{},
+        const std::string& tree_name = "")
+        : BaseClass(dimensionality, inputData, params, maximumPointCount)
+        , monitor_config_(monitor_config)
+        , tree_name_(tree_name) {
+        // Note: The dynamic adaptor will automatically add initial points if dataset is not empty
+    }
+    
+    void addPoints(IndexType start, IndexType end) {
+        size_t num_points = end - start;
+        if (num_points > 10000) {  // Only monitor large additions
+            start_monitoring("addPoints()");
+            
+            try {
+                BaseClass::addPoints(start, end);
+                stop_monitoring("addPoints()");
+            } catch (...) {
+                stop_monitoring("addPoints() (failed)");
+                throw;
+            }
+        } else {
+            BaseClass::addPoints(start, end);
+        }
+    }
+    
+    void removePoint(IndexType idx) {
+        BaseClass::removePoint(idx);
+    }
+    
+    void setMonitorConfig(const MonitorConfig& config) {
+        monitor_config_ = config;
+    }
+    
+    const MonitorConfig& getMonitorConfig() const {
+        return monitor_config_;
+    }
+    
+    void setTreeName(const std::string& name) {
+        tree_name_ = name;
+    }
+    
+    const std::string& getTreeName() const {
+        return tree_name_;
+    }
+};
+
+/**
+ * Helper function to create a monitored KD-tree with a fluent interface
+ */
+template <typename Distance, typename DatasetAdaptor, int32_t DIM = -1, typename IndexType = uint32_t>
+auto makeMonitoredKDTree(
+    const int dimensionality,
+    const DatasetAdaptor& dataset,
+    size_t threshold_mb = 100,
+    const std::string& tree_name = "") {
+    
+    using TreeType = MonitoredKDTreeSingleIndexAdaptor<Distance, DatasetAdaptor, DIM, IndexType>;
+    
+    MonitorConfig config;
+    config.threshold_mb = threshold_mb;
+    config.check_interval_ms = 50;  // More frequent checks for accuracy
+    
+    nanoflann::KDTreeSingleIndexAdaptorParams params(10);
+    
+    return TreeType(
+        dimensionality,
+        dataset,
+        params,
+        config,
+        tree_name
+    );
+}
+
+} // namespace NanoflannMonitor
+
+#endif // NANOFLANN_MONITOR_WRAPPER_HPP


### PR DESCRIPTION
Add a non-intrusive, low-overhead memory monitor for nanoflann KD-tree construction to report threshold violations.

This PR introduces a new `NanoflannMonitor` tool designed to track memory (RSS/VSS) during nanoflann's `buildIndex()` operations. It runs in a separate thread to ensure minimal impact on performance and provides configurable thresholds and logging, addressing the need for a non-intrusive and low-overhead solution for monitoring memory-intensive tree construction.

---

[Open in Web](https://cursor.com/agents?id=bc-2b95dcd9-8d24-43c6-909f-480c7750d68d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-2b95dcd9-8d24-43c6-909f-480c7750d68d) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)